### PR TITLE
fix (vector): allow pagination

### DIFF
--- a/src/__tests__/collection.test.ts
+++ b/src/__tests__/collection.test.ts
@@ -122,6 +122,18 @@ describe('emno SDK - Collection/Vector Tests', () => {
     expect(vectors!.length).toBe(vectorsMap.size);
   }, 30_000);
 
+  it('should paginate vectors successfully', async () => {
+    const collection = Array.from(collectionMap.values())[0];
+    if (!collection) {
+      throw Error('Unable to get Collection');
+    }
+    const vectorIdArray = Array.from(vectorsMap.keys());
+    const vectors = await collection.listVectors(false, 1, 1);
+    expect(vectors).toBeDefined();
+    expect(vectors!.length).toBe(1);
+    expect(vectors![0].id).toBe(vectorIdArray[1]);
+  }, 30_000);
+
   it('should query a collection successfully', async () => {
     const collection = Array.from(collectionMap.values())[0];
     if (!collection) {

--- a/src/emno/models/Collection.ts
+++ b/src/emno/models/Collection.ts
@@ -141,14 +141,20 @@ export class Collection {
   }
 
   //get list of vectors
-  async listVectors(getValue: boolean = false): Promise<Vector[] | undefined> {
+  async listVectors(
+    getValue: boolean = false,
+    offset: number = 0,
+    limit: number = 10
+  ): Promise<Vector[] | undefined> {
     const collectionId = this.id;
     if (!collectionId) {
       throw Error('Uninitialized Collection object');
     }
     const httpResponse = await this._client.listVectors(
       collectionId as string,
-      getValue
+      getValue,
+      offset,
+      limit
     );
     if (!httpResponse || httpResponse?.error || !httpResponse.responseData) {
       if (this.emnoConfig.shouldThrow) {

--- a/src/emno/utils/httpClient.ts
+++ b/src/emno/utils/httpClient.ts
@@ -226,10 +226,15 @@ export class EmnoHttpClient {
     );
   }
 
-  async listVectors(collectionId: string, includeVectorValues = false) {
+  async listVectors(
+    collectionId: string,
+    includeVectorValues = false,
+    page = 0,
+    limit = 10
+  ) {
     const requestOptions: RequestInit = {
       method: 'POST',
-      body: JSON.stringify({ includeVectorValues }),
+      body: JSON.stringify({ includeVectorValues, page, limit }),
     };
     return await this.makeAPICall<z.infer<typeof VectorListResponseSchema>>(
       `/collections/${collectionId}/vectors/getAll`,


### PR DESCRIPTION
This PR allows the `listVector` API to paginate over the list of vectors.